### PR TITLE
Update gvim_fullscreen.cpp

### DIFF
--- a/gvim_fullscreen.cpp
+++ b/gvim_fullscreen.cpp
@@ -77,7 +77,7 @@ extern "C" __declspec(dllexport) int __cdecl ToggleFullscreen(int) {
             SetPropA(hWnd, "__window_rect__", HANDLE(r));
 
             SetWindowLongPtr(hWnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
-            SetClassLongPtr(hWnd, GCL_HBRBACKGROUND, (LONG)GetStockObject(BLACK_BRUSH));
+            SetClassLongPtr(hWnd, GCLP_HBRBACKGROUND, (LONG)GetStockObject(BLACK_BRUSH));
 
             EnumDisplayMonitors(NULL, r, EnumMonitor, reinterpret_cast<LPARAM>(pmi));
             SetWindowPos(hWnd, HWND_TOP, pmi->rcMonitor.left, pmi->rcMonitor.top, pmi->rcMonitor.right - pmi->rcMonitor.left, pmi->rcMonitor.bottom - pmi->rcMonitor.top, SWP_FRAMECHANGED);
@@ -86,7 +86,7 @@ extern "C" __declspec(dllexport) int __cdecl ToggleFullscreen(int) {
             break;
         case 1:
             SetWindowLongPtr(hWnd, GWL_STYLE, WS_OVERLAPPEDWINDOW | WS_VISIBLE);
-            SetClassLongPtr(hWnd, GCL_HBRBACKGROUND, (LONG)COLOR_BTNFACE);
+            SetClassLongPtr(hWnd, GCLP_HBRBACKGROUND, (LONG)COLOR_BTNFACE);
 
             r = reinterpret_cast<RECT*>(GetPropA(hWnd, "__window_rect__"));
             SetWindowPos(hWnd, HWND_TOP, r->left, r->top, r->right-r->left, r->bottom-r->top, SWP_FRAMECHANGED);


### PR DESCRIPTION
Building generates the error: 'GCL_HBRBACKGROUND': undeclared identifier. GCL_HBRBACKGROUND is changed to GCLP_HBRBACKGROUND to fix this.